### PR TITLE
fix: stop making classmethod generic at runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ require-subclass = true
 exclude-classes = """
 (
     ^velum\\.internal\\.typing_patches:WSMessage$
-    |^velum\\.internal\\.class_utils:classmethod$
     |^velum\\.internal\\.data_binding:(_JSONLoader|_JSONDumper)$
 )
 """

--- a/velum/internal/class_utils.py
+++ b/velum/internal/class_utils.py
@@ -1,13 +1,5 @@
 import typing
 
-if not typing.TYPE_CHECKING:
-    # Ensure classmethod is generic, like typing suggests...
-
-    class classmethod(classmethod):
-        def __class_getitem__(cls, *args):
-            return cls
-
-
 T = typing.TypeVar("T")
 ClsT = typing.TypeVar("ClsT")
 
@@ -17,7 +9,7 @@ class classproperty(typing.Generic[ClsT, T]):
     __slots__: typing.Sequence[str] = ("callback",)
 
     def __init__(self, callback: typing.Callable[[typing.Type[ClsT]], T]):
-        self.callback = typing.cast(classmethod[T], callback)
+        self.callback = typing.cast("classmethod[T]", callback)
 
     def __get__(self, instance: typing.Optional[ClsT], owner: typing.Type[ClsT]) -> T:
         return self.callback.__func__(owner)  # type: ignore


### PR DESCRIPTION
This fixes a problem where in `class_utils.py`, classmethod is made generic at runtime when you don't have to.