### PR TITLE
feat(api): fetch rate limits with 0.3.3 system

### DIFF
--- a/velum/api/rest_trait.py
+++ b/velum/api/rest_trait.py
@@ -55,7 +55,7 @@ class RESTClient(typing.Protocol):
     ) -> None:
         ...
 
-    async def get_instance_info(self) -> models.InstanceInfo:
+    async def get_instance_info(self, rate_limits: bool = False) -> models.InstanceInfo:
         ...
 
     # Effis.

--- a/velum/impl/rest.py
+++ b/velum/impl/rest.py
@@ -155,15 +155,13 @@ class RESTClient(rest_trait.RESTClient):
 
         await self._request(routes.POST_MESSAGE.compile(), json=body)
 
-    async def get_instance_info(self) -> models.InstanceInfo:
-        response = await self._request(routes.GET_INFO.compile())
+    async def get_instance_info(self, rate_limits: bool = False) -> models.InstanceInfo:
+        query = {"ratelimits": "1"} if rate_limits else None
+        response = await self._request(
+            routes.GET_INFO.compile(), query=query
+        )
         assert isinstance(response, dict)
         return self._entity_factory.deserialize_instance_info(response)
-
-    async def get_ratelimits(self) -> models.InstanceRatelimits:
-        response = await self._request(routes.GET_RATELIMITS.compile())
-        assert isinstance(response, dict)
-        return self._entity_factory.deserialize_ratelimits(response)
 
     # Effis.
 

--- a/velum/routes.py
+++ b/velum/routes.py
@@ -14,7 +14,6 @@ __all__: typing.Sequence[str] = (
     "POST",
     "GET_INFO",
     "POST_MESSAGE",
-    "GET_RATELIMITS",
     "POST_ATTACHMENT",
 )
 
@@ -68,7 +67,6 @@ EFFIS: typing.Final[str] = sys.intern("EFFIS")
 
 GET_INFO = Route(GET, OPRISH, "/")
 POST_MESSAGE = Route(POST, OPRISH, "/messages")
-GET_RATELIMITS = Route(GET, OPRISH, "/ratelimits")
 
 
 # Effis routes.


### PR DESCRIPTION
<https://next.eludevs.pages.dev/reference/oprish/get_instance_info/>

`Get Instance Info` has a `rate_limits` query parameter. It only needs to be present, but aiohttp does not seem to allow clients to request using `?key` without a value. So we'll just use `?key=1` for now.

I was unsure as to if `routes.py` is included in the public API, so this has been labelled as a breaking change for now.
