### PR TITLE
fix(internal): fully type classproperty's callback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ typing-extensions = "^4.4.0"
 
 [tool.poetry.group.dev.dependencies]
 ipykernel = "^6.17.1"
-pyright = "^1.1.280"
+pyright = "^1.1.313"
 isort = "^5.10.1"
 black = "^22.10.0"
 slotscheck = "^0.16.1"

--- a/velum/internal/class_utils.py
+++ b/velum/internal/class_utils.py
@@ -11,10 +11,10 @@ class classproperty(typing.Generic[_ClsT, _T]):
 
     __slots__: typing.Sequence[str] = ("callback",)
 
-    callback: "classmethod[_T]"
+    callback: "classmethod[_ClsT, ..., _T]"
 
     def __init__(self, callback: typing.Callable[[typing.Type[_ClsT]], _T]):
-        self.callback = typing.cast("classmethod[_T]", callback)
+        self.callback = typing.cast("classmethod[_ClsT, ..., _T]", callback)
 
     def __get__(self, instance: typing.Optional[_ClsT], owner: typing.Type[_ClsT]) -> _T:
         return self.callback.__func__(owner)  # type: ignore


### PR DESCRIPTION
```python
Too few type arguments provided for "classmethod"; expected 3 but received 1
```

```python
class classmethod(Generic[_T, _P, _R_co]):
```

`_T` is the enclosing class, `_P` is the parameters and `_R_co` is the return type.
`...` is used in place of `_P` as this is a property, we do not care about the args (ideally it would be typed to be empty, but that does not seem to be possible).
