### PR TITLE
feat!: add sessions and users

### DIFF
--- a/examples/attachment.py
+++ b/examples/attachment.py
@@ -2,7 +2,7 @@ import asyncio
 
 import velum
 
-client = velum.GatewayClient()
+client = velum.RESTClient()
 
 
 def file_attachment() -> velum.Resource[velum.AsyncReader]:
@@ -27,8 +27,8 @@ def raw_attachment() -> velum.Resource:
 
 
 async def main():
-    async with client.rest as rest_client:
-        resp = await rest_client.upload_attachment(raw_attachment(), spoiler=True)
+    async with client:
+        resp = await client.upload_attachment(raw_attachment(), spoiler=True)
 
     print(resp)
 

--- a/examples/bot.py
+++ b/examples/bot.py
@@ -22,7 +22,6 @@ VELUM_URL = "https://github.com/Chromosomologist/velum"
 # `url` is optional, and should be set to `https://api.eludris.gay/next` if you want to
 # use the above instance, but with the `next` branch as users is not in main yet.
 
-__import__("logging").getLogger("velum").setLevel("DEBUG")
 bot = velum.GatewayClient(
     token=os.environ["TOKEN"],
     rest_url="https://api.eludris.gay/next",

--- a/examples/bot.py
+++ b/examples/bot.py
@@ -1,21 +1,34 @@
 import asyncio
+import os
 
 import velum
 
-SELF_AUTHOR = "Velum"  # Author name to use for messages sent to eludris.
 VELUM_URL = "https://github.com/Chromosomologist/velum"
 
 
 # By default, the client will connect to the default eludris instance at
 #
-# GATEWAY:  wss://eludris.tooty.xyz/ws/
-# REST:     https://eludris.tooty.xyz/
+# GATEWAY:  wss://ws.eludris.gay/
+# REST:     https://api.eludris.gay/
 #
 # Custom gateway and rest urls, pointing to some other eludris instance,
 # can be set though the client constructor's `gateway_url` and `rest_url`
 # arguments.
+#
+# The token can be obtained by creating a session with an existing user.
+# To create a session with velum, run `python -m velum <username> <password> [-U <url>]`
+# or `py`, `python3` or whichever variation works.
+#
+# `url` is optional, and should be set to `https://api.eludris.gay/next` if you want to
+# use the above instance, but with the `next` branch as users is not in main yet.
 
-bot = velum.GatewayClient()
+__import__("logging").getLogger("velum").setLevel("DEBUG")
+bot = velum.GatewayClient(
+    token=os.environ["TOKEN"],
+    rest_url="https://api.eludris.gay/next",
+    gateway_url="https://ws.eludris.gay/next/",
+    cdn_url="https://cdn.eludris.gay/next",
+)
 
 
 # Register a listener for messages.
@@ -25,15 +38,15 @@ bot = velum.GatewayClient()
 
 @bot.listen()
 async def on_message(event: velum.MessageCreateEvent):
-    if event.author == SELF_AUTHOR:
+    if event.author == bot.gateway.user:
         return
 
     match event.content:  # noqa: E999
         case "!pog":
-            await bot.rest.send_message(SELF_AUTHOR, "Pog!")
+            await bot.rest.send_message("Pog!")
 
         case "!velum":
-            await bot.rest.send_message(SELF_AUTHOR, VELUM_URL)
+            await bot.rest.send_message(VELUM_URL)
 
         case _:
             return

--- a/examples/exception.py
+++ b/examples/exception.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import typing
 
 import velum
@@ -8,13 +9,13 @@ import velum
 # which is an event type that is automatically dispatched when any normal
 # event raises an exception.
 
-client = velum.GatewayClient()
+client = velum.GatewayClient(token=os.environ["TOKEN"])
 
 
 @client.listen()
 async def broken_listener(event: velum.MessageCreateEvent) -> None:
     # For the sake of illustration, we immediately raise an exception.
-    if event.author != "Velum":
+    if event.author != client.gateway.user:
         raise Exception("Oops!")
 
 
@@ -27,7 +28,6 @@ async def broken_listener(event: velum.MessageCreateEvent) -> None:
 async def exception_handler(event: velum.ExceptionEvent[typing.Any]) -> None:
     if isinstance(event.failed_event, velum.MessageCreateEvent):
         await client.rest.send_message(
-            "Velum",
             f"Listener {event.failed_callback.__name__} raised an exception: {event.exception!r}",
         )
 

--- a/examples/speedups.py
+++ b/examples/speedups.py
@@ -4,6 +4,7 @@
 # opt into all the speedup features.
 
 import asyncio
+import os
 
 import uvloop
 
@@ -25,17 +26,17 @@ uvloop.install()
 
 # Finally, we instantiate and run a client as per usual.
 
-client = velum.GatewayClient()
+client = velum.GatewayClient(token=os.environ["TOKEN"])
 
 
 @client.listen()
 async def on_message(event: velum.MessageCreateEvent):
-    if event.author == "velum[speedups]":
+    if event.author == client.gateway.user:
         return
 
     match event.content:  # noqa: E999
         case "!speed":
-            await client.rest.send_message("velum[speedups]", "I am the fast.")
+            await client.rest.send_message("I am the fast.")
 
         case _:
             return

--- a/velum/__init__.py
+++ b/velum/__init__.py
@@ -18,6 +18,7 @@ from velum.events.connection_events import *
 from velum.events.message_events import *
 from velum.files import *
 from velum.impl.client import GatewayClient as GatewayClient
+from velum.impl.rest import RESTClient as RESTClient
 from velum.internal.data_binding import JSONImpl as JSONImpl
 from velum.internal.data_binding import set_json_impl as set_json_impl
-from velum.models import Message as Message
+from velum.models import *

--- a/velum/__main__.py
+++ b/velum/__main__.py
@@ -1,0 +1,34 @@
+import argparse
+import asyncio
+import typing
+
+import velum
+
+
+async def create_password(username: str, password: str, url: typing.Optional[str]) -> str:
+    async with velum.RESTClient(rest_url=url) as client:
+        token, _ = await client.create_session(
+            identifier=username,
+            password=password,
+        )
+        return token
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="velum")
+    parser.add_argument("username-or-email")
+    parser.add_argument("password")
+    parser.add_argument("--url", "-U", default=None)
+
+    args = parser.parse_args()
+
+    identifier = getattr(args, "username-or-email")
+    password = args.password
+    url = args.url
+
+    token = asyncio.run(create_password(identifier, password, url))
+    print(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/velum/api/entity_factory_trait.py
+++ b/velum/api/entity_factory_trait.py
@@ -36,6 +36,9 @@ class EntityFactory(typing.Protocol):
     def deserialize_session(self, payload: data_binding.JSONObject) -> models.Session:
         ...
 
+    def deserialize_user(self, payload: data_binding.JSONObject) -> models.User:
+        ...
+
     def deserialize_authenticated(self, payload: data_binding.JSONObject) -> models.Authenticated:
         ...
 

--- a/velum/api/entity_factory_trait.py
+++ b/velum/api/entity_factory_trait.py
@@ -28,6 +28,14 @@ class EntityFactory(typing.Protocol):
     def deserialize_ratelimit(self, payload: data_binding.JSONObject) -> models.RatelimitData:
         ...
 
+    def deserialize_session_created(
+        self, payload: data_binding.JSONObject
+    ) -> typing.Tuple[str, models.Session]:
+        ...
+
+    def deserialize_session(self, payload: data_binding.JSONObject) -> models.Session:
+        ...
+
     def deserialize_authenticated(self, payload: data_binding.JSONObject) -> models.Authenticated:
         ...
 

--- a/velum/api/entity_factory_trait.py
+++ b/velum/api/entity_factory_trait.py
@@ -27,3 +27,6 @@ class EntityFactory(typing.Protocol):
 
     def deserialize_ratelimit(self, payload: data_binding.JSONObject) -> models.RatelimitData:
         ...
+
+    def deserialize_authenticated(self, payload: data_binding.JSONObject) -> models.Authenticated:
+        ...

--- a/velum/api/entity_factory_trait.py
+++ b/velum/api/entity_factory_trait.py
@@ -30,3 +30,8 @@ class EntityFactory(typing.Protocol):
 
     def deserialize_authenticated(self, payload: data_binding.JSONObject) -> models.Authenticated:
         ...
+
+    def deserialize_presence_update(
+        self, payload: data_binding.JSONObject
+    ) -> models.PresenceUpdate:
+        ...

--- a/velum/api/event_factory_trait.py
+++ b/velum/api/event_factory_trait.py
@@ -47,3 +47,10 @@ class EventFactory(typing.Protocol):
         payload: data_binding.JSONObject,
     ) -> user_events.UserUpdateEvent:
         ...
+
+    def deserialize_presence_update_event(
+        self,
+        gateway_connection: gateway_trait.GatewayHandler,
+        payload: data_binding.JSONObject,
+    ) -> user_events.PresenceUpdateEvent:
+        ...

--- a/velum/api/event_factory_trait.py
+++ b/velum/api/event_factory_trait.py
@@ -32,3 +32,10 @@ class EventFactory(typing.Protocol):
         payload: data_binding.JSONObject,
     ) -> connection_events.RatelimitEvent:
         ...
+
+    def deserialize_authenticated_event(
+        self,
+        gateway_connection: gateway_trait.GatewayHandler,
+        payload: data_binding.JSONObject,
+    ) -> connection_events.AuthenticatedEvent:
+        ...

--- a/velum/api/event_factory_trait.py
+++ b/velum/api/event_factory_trait.py
@@ -3,6 +3,7 @@ import typing
 from velum.api import gateway_trait as gateway_trait
 from velum.events import connection_events
 from velum.events import message_events
+from velum.events import user_events
 from velum.internal import data_binding
 
 __all__: typing.Sequence[str] = ("EventFactory",)
@@ -38,4 +39,11 @@ class EventFactory(typing.Protocol):
         gateway_connection: gateway_trait.GatewayHandler,
         payload: data_binding.JSONObject,
     ) -> connection_events.AuthenticatedEvent:
+        ...
+
+    def deserialize_user_update_event(
+        self,
+        gateway_connection: gateway_trait.GatewayHandler,
+        payload: data_binding.JSONObject,
+    ) -> user_events.UserUpdateEvent:
         ...

--- a/velum/api/gateway_trait.py
+++ b/velum/api/gateway_trait.py
@@ -1,5 +1,7 @@
 import typing
 
+from velum import models
+
 __all__: typing.Sequence[str] = ("GatewayHandler",)
 
 
@@ -9,6 +11,10 @@ class GatewayHandler(typing.Protocol):
 
     @property
     def is_alive(self) -> bool:
+        ...
+
+    @property
+    def user(self) -> models.User:
         ...
 
     async def start(self) -> None:

--- a/velum/api/rest_trait.py
+++ b/velum/api/rest_trait.py
@@ -98,3 +98,48 @@ class RESTClient(typing.Protocol):
 
     async def get_sessions(self) -> typing.Sequence[models.Session]:
         ...
+
+    # Users
+
+    async def create_user(
+        self,
+        *,
+        username: str,
+        email: str,
+        password: str,
+    ) -> models.User:
+        ...
+
+    async def delete_user(self, password: str) -> None:
+        ...
+
+    async def get_self(self) -> models.User:
+        ...
+
+    async def get_user(self, identifier: typing.Union[int, str], /) -> models.User:
+        ...
+
+    async def update_profile(
+        self,
+        *,
+        display_name: typing.Optional[str] = None,
+        status: typing.Optional[str] = None,
+        status_type: typing.Optional[models.StatusType] = None,
+        bio: typing.Optional[str] = None,
+        avatar: typing.Optional[int] = None,
+        banner: typing.Optional[int] = None,
+    ) -> models.User:
+        ...
+
+    async def update_user(
+        self,
+        *,
+        password: str,
+        username: typing.Optional[str] = None,
+        email: typing.Optional[str] = None,
+        new_password: typing.Optional[str] = None,
+    ) -> models.User:
+        ...
+
+    async def verify_user(self, *, code: int) -> None:
+        ...

--- a/velum/api/rest_trait.py
+++ b/velum/api/rest_trait.py
@@ -85,3 +85,16 @@ class RESTClient(typing.Protocol):
 
     async def send_message(self, content: str) -> models.Message:
         ...
+
+    # Sessions
+
+    async def create_session(
+        self, *, identifier: str, password: str, platform: str = ..., client: str = ...
+    ) -> typing.Tuple[str, models.Session]:
+        ...
+
+    async def delete_session(self, *, id: int) -> None:
+        ...
+
+    async def get_sessions(self) -> typing.Sequence[models.Session]:
+        ...

--- a/velum/api/rest_trait.py
+++ b/velum/api/rest_trait.py
@@ -39,25 +39,8 @@ class RESTClient(typing.Protocol):
     ) -> None:
         ...
 
-    @typing.overload
-    async def send_message(self, *, message: models.Message) -> None:
-        ...
-
-    @typing.overload
-    async def send_message(self, author: str, message: str) -> None:
-        ...
-
-    async def send_message(
-        self,
-        author: typing.Optional[str] = None,
-        message: typing.Optional[models.Message | str] = None,
-    ) -> None:
-        ...
-
-    async def get_instance_info(self, rate_limits: bool = False) -> models.InstanceInfo:
-        ...
-
-    # Effis.
+    # Ordered by docs.
+    # Files.
 
     async def upload_to_bucket(
         self,
@@ -91,4 +74,14 @@ class RESTClient(typing.Protocol):
         ...
 
     async def fetch_static_file(self, name: str) -> files.URL:
+        ...
+
+    # Instance.
+
+    async def get_instance_info(self, rate_limits: bool = False) -> models.InstanceInfo:
+        ...
+
+    # Messaging.
+
+    async def send_message(self, content: str) -> models.Message:
         ...

--- a/velum/events/__init__.py
+++ b/velum/events/__init__.py
@@ -2,3 +2,4 @@ from velum.events.base_events import Event as Event
 from velum.events.base_events import ExceptionEvent as ExceptionEvent
 from velum.events.connection_events import *
 from velum.events.message_events import *
+from velum.events.user_events import *

--- a/velum/events/connection_events.py
+++ b/velum/events/connection_events.py
@@ -10,6 +10,7 @@ __all__: typing.Sequence[str] = (
     "DisconnectEvent",
     "HelloEvent",
     "RatelimitEvent",
+    "AuthenticatedEvent",
 )
 
 
@@ -63,3 +64,22 @@ class RatelimitEvent(base_events.Event):
         """The number of milliseconds to wait for the rate-limit to wear off."""
 
         return self.data.wait
+
+
+@attr.define(kw_only=True, weakref_slot=False)
+class AuthenticatedEvent(base_events.Event):
+    """Event fired when the client is authenticated."""
+
+    data: models.Authenticated = attr.field()
+
+    @property
+    def user(self) -> models.User:
+        """The currently authenticated user."""
+
+        return self.data.user
+
+    @property
+    def users(self) -> typing.Sequence[models.User]:
+        """The online users relevant to the authenticated user."""
+
+        return self.data.users

--- a/velum/events/message_events.py
+++ b/velum/events/message_events.py
@@ -21,7 +21,7 @@ class MessageCreateEvent(MessageEvent):
     message: models.Message = attr.field()
 
     @property
-    def author(self) -> str:
+    def author(self) -> models.User:
         return self.message.author
 
     @property

--- a/velum/events/user_events.py
+++ b/velum/events/user_events.py
@@ -2,12 +2,22 @@ from __future__ import annotations
 
 import typing
 
+import attr
+
+from velum import models
 from velum.events import base_events
 
-__all__: typing.Sequence[str] = ()
+__all__: typing.Sequence[str] = ("UserUpdateEvent",)
 
 
 class UserEvent(base_events.Event):
     """Any event concerning users."""
 
     __slots__ = ()
+
+
+@attr.define(kw_only=True, weakref_slot=False)
+class UserUpdateEvent(UserEvent):
+    """Event fired when a user's information is updated."""
+
+    user: models.User = attr.field()

--- a/velum/events/user_events.py
+++ b/velum/events/user_events.py
@@ -7,7 +7,10 @@ import attr
 from velum import models
 from velum.events import base_events
 
-__all__: typing.Sequence[str] = ("UserUpdateEvent",)
+__all__: typing.Sequence[str] = (
+    "UserUpdateEvent",
+    "PresenceUpdateEvent",
+)
 
 
 class UserEvent(base_events.Event):
@@ -21,3 +24,22 @@ class UserUpdateEvent(UserEvent):
     """Event fired when a user's information is updated."""
 
     user: models.User = attr.field()
+
+
+@attr.define(kw_only=True, weakref_slot=False)
+class PresenceUpdateEvent(UserEvent):
+    """Event fired when a user's presence is updated."""
+
+    data: models.PresenceUpdate = attr.field()
+
+    @property
+    def user_id(self) -> int:
+        """The id of the user."""
+
+        return self.data.user_id
+
+    @property
+    def status(self) -> models.Status:
+        """The status of the user."""
+
+        return self.data.status

--- a/velum/events/user_events.py
+++ b/velum/events/user_events.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import typing
+
+from velum.events import base_events
+
+__all__: typing.Sequence[str] = ()
+
+
+class UserEvent(base_events.Event):
+    """Any event concerning users."""
+
+    __slots__ = ()

--- a/velum/impl/client.py
+++ b/velum/impl/client.py
@@ -55,6 +55,8 @@ class GatewayClient(traits.GatewayClientAware):
         event_manager_impl: typing.Optional[event_manager_trait.EventManager] = None,
         gateway_impl: typing.Optional[gateway_trait.GatewayHandler] = None,
         rest_client_impl: typing.Optional[rest_trait.RESTClient] = None,
+        *,
+        token: str,
     ):
         self._entity_factory = (
             entity_factory_impl
@@ -79,6 +81,7 @@ class GatewayClient(traits.GatewayClientAware):
             else rest.RESTClient(
                 rest_url=rest_url,
                 cdn_url=cdn_url,
+                token=token,
                 entity_factory=self._entity_factory,
             )
         )
@@ -87,7 +90,9 @@ class GatewayClient(traits.GatewayClientAware):
         self._gateway = (
             gateway_impl
             if gateway_impl is not None
-            else gateway.GatewayHandler(gateway_url=gateway_url, event_manager=self._event_manager)
+            else gateway.GatewayHandler(
+                gateway_url=gateway_url, event_manager=self._event_manager, token=token
+            )
         )
 
         # Setup state.

--- a/velum/impl/entity_factory.py
+++ b/velum/impl/entity_factory.py
@@ -12,7 +12,7 @@ class EntityFactory(entity_factory_trait.EntityFactory):
 
     def deserialize_message(self, payload: data_binding.JSONObject) -> models.Message:
         content = typing.cast(str, payload["content"])
-        author = typing.cast(str, payload["author"])
+        author = self.deserialize_user(typing.cast(data_binding.JSONObject, payload["author"]))
 
         return models.Message(content=content, author=author)
 

--- a/velum/impl/entity_factory.py
+++ b/velum/impl/entity_factory.py
@@ -171,3 +171,9 @@ class EntityFactory(entity_factory_trait.EntityFactory):
         wait = typing.cast(int, payload["wait"])
 
         return models.RatelimitData(wait=wait)
+
+    def deserialize_authenticated(self, payload: data_binding.JSONObject) -> models.Authenticated:
+        user = self.deserialize_user(typing.cast(data_binding.JSONObject, payload["user"]))
+        users = typing.cast(typing.List[models.User], payload["users"])
+
+        return models.Authenticated(user=user, users=users)

--- a/velum/impl/entity_factory.py
+++ b/velum/impl/entity_factory.py
@@ -196,6 +196,41 @@ class EntityFactory(entity_factory_trait.EntityFactory):
             ip=ipaddress.ip_address(ip),
         )
 
+    def _deserialize_status(self, payload: data_binding.JSONObject) -> models.Status:
+        type = typing.cast(str, payload["type"])
+        text = typing.cast(typing.Optional[str], payload.get("text"))
+
+        return models.Status(type=models.StatusType(type), text=text)
+
+    def deserialize_user(self, payload: data_binding.JSONObject) -> models.User:
+        id = typing.cast(int, payload["id"])
+        username = typing.cast(str, payload["username"])
+        display_name = typing.cast(typing.Optional[str], payload.get("display_name"))
+        social_credit = typing.cast(int, payload["social_credit"])
+        status = self._deserialize_status(typing.cast(data_binding.JSONObject, payload["status"]))
+        bio = typing.cast(typing.Optional[str], payload.get("bio"))
+        avatar = typing.cast(typing.Optional[int], payload.get("avatar"))
+        banner = typing.cast(typing.Optional[int], payload.get("banner"))
+        badges = typing.cast(int, payload["badges"])
+        permissions = typing.cast(int, payload["permissions"])
+        email = typing.cast(typing.Optional[str], payload.get("email"))
+        verified = typing.cast(typing.Optional[bool], payload.get("verified"))
+
+        return models.User(
+            id=id,
+            username=username,
+            display_name=display_name,
+            social_credit=social_credit,
+            status=status,
+            bio=bio,
+            avatar=avatar,
+            banner=banner,
+            badges=badges,
+            permissions=permissions,
+            email=email,
+            verified=verified,
+        )
+
     def deserialize_authenticated(self, payload: data_binding.JSONObject) -> models.Authenticated:
         user = self.deserialize_user(typing.cast(data_binding.JSONObject, payload["user"]))
         users = typing.cast(typing.List[models.User], payload["users"])

--- a/velum/impl/entity_factory.py
+++ b/velum/impl/entity_factory.py
@@ -1,3 +1,4 @@
+import ipaddress
 import typing
 
 from velum import models
@@ -171,6 +172,29 @@ class EntityFactory(entity_factory_trait.EntityFactory):
         wait = typing.cast(int, payload["wait"])
 
         return models.RatelimitData(wait=wait)
+
+    def deserialize_session_created(
+        self, payload: data_binding.JSONObject
+    ) -> typing.Tuple[str, models.Session]:
+        token = typing.cast(str, payload["token"])
+        session = self.deserialize_session(typing.cast(data_binding.JSONObject, payload["session"]))
+
+        return token, session
+
+    def deserialize_session(self, payload: data_binding.JSONObject) -> models.Session:
+        id = typing.cast(int, payload["id"])
+        user_id = typing.cast(int, payload["user_id"])
+        platform = typing.cast(str, payload["platform"])
+        client = typing.cast(str, payload["client"])
+        ip = typing.cast(str, payload["ip"])
+
+        return models.Session(
+            id=id,
+            user_id=user_id,
+            platform=platform,
+            client=client,
+            ip=ipaddress.ip_address(ip),
+        )
 
     def deserialize_authenticated(self, payload: data_binding.JSONObject) -> models.Authenticated:
         user = self.deserialize_user(typing.cast(data_binding.JSONObject, payload["user"]))

--- a/velum/impl/entity_factory.py
+++ b/velum/impl/entity_factory.py
@@ -177,3 +177,11 @@ class EntityFactory(entity_factory_trait.EntityFactory):
         users = typing.cast(typing.List[models.User], payload["users"])
 
         return models.Authenticated(user=user, users=users)
+
+    def deserialize_presence_update(
+        self, payload: data_binding.JSONObject
+    ) -> models.PresenceUpdate:
+        user_id = typing.cast(int, payload["user_id"])
+        status = self._deserialize_status(typing.cast(data_binding.JSONObject, payload["status"]))
+
+        return models.PresenceUpdate(user_id=user_id, status=status)

--- a/velum/impl/event_factory.py
+++ b/velum/impl/event_factory.py
@@ -42,3 +42,12 @@ class EventFactory(event_factory_trait.EventFactory):
         return message_events.MessageCreateEvent(
             message=self._entity_factory.deserialize_message(payload)
         )
+
+    def deserialize_authenticated_event(
+        self,
+        gateway_connection: gateway_trait.GatewayHandler,
+        payload: data_binding.JSONObject,
+    ) -> connection_events.AuthenticatedEvent:
+        return connection_events.AuthenticatedEvent(
+            data=self._entity_factory.deserialize_authenticated(payload)
+        )

--- a/velum/impl/event_factory.py
+++ b/velum/impl/event_factory.py
@@ -7,6 +7,7 @@ from velum.api import event_factory_trait
 from velum.api import gateway_trait
 from velum.events import connection_events
 from velum.events import message_events
+from velum.events import user_events
 from velum.internal import data_binding
 
 __all__: typing.Sequence[str] = ("EventFactory",)
@@ -51,3 +52,10 @@ class EventFactory(event_factory_trait.EventFactory):
         return connection_events.AuthenticatedEvent(
             data=self._entity_factory.deserialize_authenticated(payload)
         )
+
+    def deserialize_user_update_event(
+        self,
+        gateway_connection: gateway_trait.GatewayHandler,
+        payload: data_binding.JSONObject,
+    ) -> user_events.UserUpdateEvent:
+        return user_events.UserUpdateEvent(user=self._entity_factory.deserialize_user(payload))

--- a/velum/impl/event_factory.py
+++ b/velum/impl/event_factory.py
@@ -59,3 +59,12 @@ class EventFactory(event_factory_trait.EventFactory):
         payload: data_binding.JSONObject,
     ) -> user_events.UserUpdateEvent:
         return user_events.UserUpdateEvent(user=self._entity_factory.deserialize_user(payload))
+
+    def deserialize_presence_update_event(
+        self,
+        gateway_connection: gateway_trait.GatewayHandler,
+        payload: data_binding.JSONObject,
+    ) -> user_events.PresenceUpdateEvent:
+        return user_events.PresenceUpdateEvent(
+            data=self._entity_factory.deserialize_presence_update(payload)
+        )

--- a/velum/impl/event_manager.py
+++ b/velum/impl/event_manager.py
@@ -67,3 +67,13 @@ class EventManager(event_manager_base.EventManagerBase):
         await self.dispatch(
             self._event_factory.deserialize_user_update_event(gateway_connection, payload)
         )
+
+    @event_manager_base.is_consumer_for(user_events.PresenceUpdateEvent)
+    async def on_presence_update(
+        self,
+        gateway_connection: gateway_trait.GatewayHandler,
+        payload: data_binding.JSONObject,
+    ) -> None:
+        await self.dispatch(
+            self._event_factory.deserialize_presence_update_event(gateway_connection, payload)
+        )

--- a/velum/impl/event_manager.py
+++ b/velum/impl/event_manager.py
@@ -46,3 +46,13 @@ class EventManager(event_manager_base.EventManagerBase):
         await self.dispatch(
             self._event_factory.deserialize_ratelimit_event(gateway_connection, payload)
         )
+
+    @event_manager_base.is_consumer_for(connection_events.AuthenticatedEvent)
+    async def on_authenticated(
+        self,
+        gateway_connection: gateway_trait.GatewayHandler,
+        payload: data_binding.JSONObject,
+    ) -> None:
+        await self.dispatch(
+            self._event_factory.deserialize_authenticated_event(gateway_connection, payload)
+        )

--- a/velum/impl/event_manager.py
+++ b/velum/impl/event_manager.py
@@ -4,6 +4,7 @@ from velum.api import event_factory_trait
 from velum.api import gateway_trait
 from velum.events import connection_events
 from velum.events import message_events
+from velum.events import user_events
 from velum.impl import event_manager_base
 from velum.internal import data_binding
 
@@ -55,4 +56,14 @@ class EventManager(event_manager_base.EventManagerBase):
     ) -> None:
         await self.dispatch(
             self._event_factory.deserialize_authenticated_event(gateway_connection, payload)
+        )
+
+    @event_manager_base.is_consumer_for(user_events.UserUpdateEvent)
+    async def on_user_update(
+        self,
+        gateway_connection: gateway_trait.GatewayHandler,
+        payload: data_binding.JSONObject,
+    ) -> None:
+        await self.dispatch(
+            self._event_factory.deserialize_user_update_event(gateway_connection, payload)
         )

--- a/velum/impl/gateway.py
+++ b/velum/impl/gateway.py
@@ -183,11 +183,10 @@ class GatewayWebsocket:
 
 class GatewayHandler(gateway_trait.GatewayHandler):
     __slots__ = (
-        "_event_manager",
-        "_connection_event",
         "_authenticated_event",
+        "_connection_event",
+        "_event_manager",
         "_gateway_url",
-        "_token",
         "_gateway_ws",
         "_heartbeat_latency",
         "_is_closing",
@@ -196,6 +195,7 @@ class GatewayHandler(gateway_trait.GatewayHandler):
         "_last_heartbeat_ack",
         "_logger",
         "_started_at",
+        "_token",
         "_user",
     )
 

--- a/velum/impl/gateway.py
+++ b/velum/impl/gateway.py
@@ -187,6 +187,7 @@ class GatewayHandler(gateway_trait.GatewayHandler):
         "_connection_event",
         "_authenticated_event",
         "_gateway_url",
+        "_token",
         "_gateway_ws",
         "_heartbeat_latency",
         "_is_closing",
@@ -209,13 +210,13 @@ class GatewayHandler(gateway_trait.GatewayHandler):
     _logger: logging.Logger
     _started_at: float
     _user: typing.Optional[models.User]
-    _started_at: float
 
     def __init__(
         self,
         *,
         gateway_url: typing.Optional[str] = None,
         event_manager: event_manager_trait.EventManager,
+        token: str,
     ):
         self._event_manager = event_manager
 
@@ -224,6 +225,7 @@ class GatewayHandler(gateway_trait.GatewayHandler):
         self._connection_event = None
         self._authenticated_event = asyncio.Event()
         self._gateway_url = gateway_url or _GATEWAY_URL
+        self._token = token
         self._gateway_ws = None
         self._heartbeat_latency = float("nan")
         self._keep_alive_task = None

--- a/velum/impl/rest.py
+++ b/velum/impl/rest.py
@@ -231,3 +231,75 @@ class RESTClient(rest_trait.RESTClient):
             )
             for session in response
         ]
+
+    # Users
+
+    async def create_user(
+        self,
+        *,
+        username: str,
+        email: str,
+        password: str,
+    ) -> models.User:
+        body = {"username": username, "email": email, "password": password}
+        response = await self._request(routes.CREATE_USER.compile(), json=body)
+        assert isinstance(response, dict)
+        return self._entity_factory.deserialize_user(response)
+
+    async def delete_user(self, password: str) -> None:
+        body = {"password": password}
+        await self._request(routes.DELETE_USER.compile(), json=body)
+
+    async def get_self(self) -> models.User:
+        response = await self._request(routes.GET_SELF.compile())
+        assert isinstance(response, dict)
+        return self._entity_factory.deserialize_user(response)
+
+    async def get_user(self, identifier: typing.Union[int, str], /) -> models.User:
+        response = await self._request(routes.GET_USER.compile(identifier=identifier))
+        assert isinstance(response, dict)
+        return self._entity_factory.deserialize_user(response)
+
+    async def update_profile(
+        self,
+        *,
+        display_name: typing.Optional[str] = None,
+        status: typing.Optional[str] = None,
+        status_type: typing.Optional[models.StatusType] = None,
+        bio: typing.Optional[str] = None,
+        avatar: typing.Optional[int] = None,
+        banner: typing.Optional[int] = None,
+    ) -> models.User:
+        body = {
+            "display_name": display_name,
+            "status": status,
+            "status_type": status_type,
+            "bio": bio,
+            "avatar": avatar,
+            "banner": banner,
+        }
+        response = await self._request(routes.UPDATE_PROFILE.compile(), json=body)
+        assert isinstance(response, dict)
+        return self._entity_factory.deserialize_user(response)
+
+    async def update_user(
+        self,
+        *,
+        password: str,
+        username: typing.Optional[str] = None,
+        email: typing.Optional[str] = None,
+        new_password: typing.Optional[str] = None,
+    ) -> models.User:
+        body = {
+            "password": password,
+            "username": username,
+            "email": email,
+            "new_password": new_password,
+        }
+        response = await self._request(routes.UPDATE_USER.compile(), json=body)
+        assert isinstance(response, dict)
+        return self._entity_factory.deserialize_user(response)
+
+    async def verify_user(self, *, code: int) -> None:
+        query = {"code": str(code)}
+        await self._request(routes.VERIFY_USER.compile(), query=query)

--- a/velum/impl/rest.py
+++ b/velum/impl/rest.py
@@ -226,9 +226,7 @@ class RESTClient(rest_trait.RESTClient):
         response = await self._request(routes.GET_SESSIONS.compile())
         assert isinstance(response, list)
         return [
-            self._entity_factory.deserialize_session(
-                typing.cast(typing.Dict[str, typing.Any], session)
-            )
+            self._entity_factory.deserialize_session(typing.cast(data_binding.JSONObject, session))
             for session in response
         ]
 

--- a/velum/impl/rest.py
+++ b/velum/impl/rest.py
@@ -203,3 +203,31 @@ class RESTClient(rest_trait.RESTClient):
         response = await self._request(routes.CREATE_MESSAGE.compile(), json=body)
         assert isinstance(response, dict)
         return self._entity_factory.deserialize_message(response)
+
+    # Sessions
+
+    async def create_session(
+        self, *, identifier: str, password: str, platform: str = "python", client: str = "velum"
+    ) -> typing.Tuple[str, models.Session]:
+        body = {
+            "identifier": identifier,
+            "password": password,
+            "platform": platform,
+            "client": client,
+        }
+        response = await self._request(routes.CREATE_SESSION.compile(), json=body)
+        assert isinstance(response, dict)
+        return self._entity_factory.deserialize_session_created(response)
+
+    async def delete_session(self, *, id: int) -> None:
+        await self._request(routes.DELETE_SESSION.compile(id=id))
+
+    async def get_sessions(self) -> typing.Sequence[models.Session]:
+        response = await self._request(routes.GET_SESSIONS.compile())
+        assert isinstance(response, list)
+        return [
+            self._entity_factory.deserialize_session(
+                typing.cast(typing.Dict[str, typing.Any], session)
+            )
+            for session in response
+        ]

--- a/velum/models.py
+++ b/velum/models.py
@@ -326,3 +326,14 @@ class User:
 
     This is only available when getting the data of the currently authenticated user.
     """
+
+
+@attr.define(kw_only=True, weakref_slot=False)
+class PresenceUpdate:
+    """Represents a presence update."""
+
+    user_id: int
+    """The id of the user."""
+
+    status: Status
+    """The status of the user."""

--- a/velum/models.py
+++ b/velum/models.py
@@ -45,6 +45,17 @@ class Hello:
 
 
 @attr.define(kw_only=True, weakref_slot=False)
+class Authenticated:
+    """Represents the payload sent by the gateway upon authentication."""
+
+    user: User
+    """The currently authenticated user."""
+
+    users: typing.Sequence[User]
+    """The online users relevant to the authenticated user."""
+
+
+@attr.define(kw_only=True, weakref_slot=False)
 class Message:
     """Represents a message on Eludris."""
 

--- a/velum/models.py
+++ b/velum/models.py
@@ -12,6 +12,7 @@ __all__: typing.Sequence[str] = (
     "Session",
     "StatusType",
     "Status",
+    "User",
 )
 
 
@@ -267,3 +268,50 @@ class Status:
 
     text: typing.Optional[str] = attr.field()
     """The text of the status."""
+
+
+@attr.define(kw_only=True, weakref_slot=False)
+class User:
+    """Represents a user on an Eludris instance."""
+
+    id: int
+    """The id of the user."""
+
+    username: str
+    """The username of the user."""
+
+    display_name: typing.Optional[str] = attr.field(default=None)
+    """The display name of the user."""
+
+    social_credit: int
+    """The social credit of the user."""
+
+    status: Status
+    """The status of the user."""
+
+    bio: typing.Optional[str] = attr.field(default=None)
+    """The bio of the user."""
+
+    avatar: typing.Optional[int] = attr.field(default=None)
+    """The avatar of the user."""
+
+    banner: typing.Optional[int] = attr.field(default=None)
+    """The banner of the user."""
+
+    badges: int
+    """The badges of the user."""
+
+    permissions: int
+    """The permissions of the user."""
+
+    email: typing.Optional[str] = attr.field(default=None)
+    """The email of the user.
+
+    This is only available when getting the data of the currently authenticated user.
+    """
+
+    verified: typing.Optional[bool] = attr.field(default=None)
+    """Whether or not the user is verified.
+
+    This is only available when getting the data of the currently authenticated user.
+    """

--- a/velum/models.py
+++ b/velum/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 import typing
+from enum import Enum
 
 import attr
 
@@ -9,6 +10,8 @@ __all__: typing.Sequence[str] = (
     "Message",
     "InstanceInfo",
     "Session",
+    "StatusType",
+    "Status",
 )
 
 
@@ -237,3 +240,30 @@ class Session:
 
     ip: typing.Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
     """The IP address the session was created from."""
+
+
+class StatusType(Enum):
+    """Represents the type of a status."""
+
+    ONLINE = "ONLINE"
+    """The user is online."""
+
+    OFFLINE = "OFFLINE"
+    """The user is offline."""
+
+    IDLE = "IDLE"
+    """The user is idle."""
+
+    BUSY = "BUSY"
+    """The user is busy."""
+
+
+@attr.define(kw_only=True, weakref_slot=False)
+class Status:
+    """Represents the status of a user."""
+
+    type: StatusType = attr.field()
+    """The type of the status."""
+
+    text: typing.Optional[str] = attr.field()
+    """The text of the status."""

--- a/velum/models.py
+++ b/velum/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ipaddress
 import typing
 
 import attr
@@ -7,6 +8,7 @@ import attr
 __all__: typing.Sequence[str] = (
     "Message",
     "InstanceInfo",
+    "Session",
 )
 
 
@@ -215,3 +217,23 @@ class InstanceInfo:
 
     rate_limits: typing.Optional[InstanceRatelimits] = attr.field()
     """The ratelimits that apply to the connected Eludris instance."""
+
+
+@attr.define(kw_only=True, weakref_slot=False)
+class Session:
+    """Represents an authenticated session with an Eludris instance."""
+
+    id: int
+    """The id of the session."""
+
+    user_id: int
+    """The id of the user that owns the session."""
+
+    platform: str
+    """The platform the session was created on."""
+
+    client: str
+    """The client the session was created by."""
+
+    ip: typing.Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+    """The IP address the session was created from."""

--- a/velum/models.py
+++ b/velum/models.py
@@ -48,7 +48,7 @@ class Hello:
 class Message:
     """Represents a message on Eludris."""
 
-    author: str = attr.field()
+    author: User = attr.field()
     """The author of the message."""
 
     content: str = attr.field()

--- a/velum/routes.py
+++ b/velum/routes.py
@@ -12,9 +12,10 @@ __all__: typing.Sequence[str] = (
     "CompiledRoute",
     "GET",
     "POST",
+    "PATCH",
+    "DELETE",
     "GET_INFO",
-    "POST_MESSAGE",
-    "POST_ATTACHMENT",
+    "CREATE_MESSAGE",
 )
 
 
@@ -26,8 +27,12 @@ class Route:
 
     path_template: str = attr.field()
 
+    requires_authentication: typing.Optional[bool] = attr.field(default=None)
+
     def compile(self, **url_params: typing.Any) -> CompiledRoute:
-        return CompiledRoute(self, self.path_template.format_map(url_params))
+        return CompiledRoute(
+            self, self.path_template.format_map(url_params), self.requires_authentication
+        )
 
     def __str__(self) -> str:
         return self.path_template
@@ -38,6 +43,8 @@ class CompiledRoute:
     route: Route = attr.field()
 
     compiled_path: str = attr.field()
+
+    requires_authentication: typing.Optional[bool] = attr.field(default=None)
 
     @property
     def method(self) -> str:
@@ -56,18 +63,14 @@ class CompiledRoute:
 
 GET: typing.Final[str] = "GET"
 POST: typing.Final[str] = "POST"
+PATCH: typing.Final[str] = "PATCH"
+DELETE: typing.Final[str] = "DELETE"
 
 OPRISH: typing.Final[str] = sys.intern("OPRISH")
 EFFIS: typing.Final[str] = sys.intern("EFFIS")
 
 
-# Oprish routes.
-
-GET_INFO = Route(GET, OPRISH, "/")
-POST_MESSAGE = Route(POST, OPRISH, "/messages")
-
-
-# Effis routes.
+# Files.
 
 POST_ATTACHMENT = Route(POST, EFFIS, "/")
 GET_ATTACHMENT = Route(GET, EFFIS, "/{id}")
@@ -76,3 +79,11 @@ POST_FILE = Route(POST, EFFIS, "/{bucket}")
 GET_FILE = Route(GET, EFFIS, "/{bucket}/{id}")
 GET_FILE_INFO = Route(GET, EFFIS, "/{bucket}/{id}/data")
 GET_STATIC_FILE = Route(GET, EFFIS, "/static/{name}")
+
+# Instance.
+
+GET_INFO = Route(GET, OPRISH, "/")
+
+# Messaging.
+
+CREATE_MESSAGE = Route(POST, OPRISH, "/messages", True)

--- a/velum/routes.py
+++ b/velum/routes.py
@@ -16,6 +16,9 @@ __all__: typing.Sequence[str] = (
     "DELETE",
     "GET_INFO",
     "CREATE_MESSAGE",
+    "CREATE_SESSION",
+    "DELETE_SESSION",
+    "GET_SESSIONS",
 )
 
 
@@ -87,3 +90,9 @@ GET_INFO = Route(GET, OPRISH, "/")
 # Messaging.
 
 CREATE_MESSAGE = Route(POST, OPRISH, "/messages", True)
+
+# Sessions.
+
+CREATE_SESSION = Route(POST, OPRISH, "/sessions")
+DELETE_SESSION = Route(DELETE, OPRISH, "/sessions/{id}", True)
+GET_SESSIONS = Route(GET, OPRISH, "/sessions", True)

--- a/velum/routes.py
+++ b/velum/routes.py
@@ -19,6 +19,13 @@ __all__: typing.Sequence[str] = (
     "CREATE_SESSION",
     "DELETE_SESSION",
     "GET_SESSIONS",
+    "CREATE_USER",
+    "DELETE_USER",
+    "GET_SELF",
+    "GET_USER",
+    "UPDATE_PROFILE",
+    "UPDATE_USER",
+    "VERIFY_USER",
 )
 
 
@@ -96,3 +103,13 @@ CREATE_MESSAGE = Route(POST, OPRISH, "/messages", True)
 CREATE_SESSION = Route(POST, OPRISH, "/sessions")
 DELETE_SESSION = Route(DELETE, OPRISH, "/sessions/{id}", True)
 GET_SESSIONS = Route(GET, OPRISH, "/sessions", True)
+
+# Users.
+
+CREATE_USER = Route(POST, OPRISH, "/users")
+DELETE_USER = Route(DELETE, OPRISH, "/users", True)
+GET_SELF = Route(GET, OPRISH, "/users/@me", True)
+GET_USER = Route(GET, OPRISH, "/users/{identifier}", False)
+UPDATE_PROFILE = Route(PATCH, OPRISH, "/users/profile", True)
+UPDATE_USER = Route(PATCH, OPRISH, "/users", True)
+VERIFY_USER = Route(POST, OPRISH, "/users/verify", True)


### PR DESCRIPTION
**This will be a draft for at least as long as `eludris/eludris`' `enoki/users` branch is not merged. <ins>Ideally this PR would target some sort of `next` branch</ins> as 0.4 would not be an "official" version when it is in `next` on `eludris/eludris`.**

- [x] Deserialization
- [x] Routes
- [x] Models
- [x] REST token auth
- [x] Gateway token auth
- ~~[ ] Examples~~
- [x] Ability to generate token from username/password (likely external thing you run once to get the token, but will set `velum` as the client field) - `python -m velum`

test code: https://enokiun.github.io/effiwbin/?id=2403121365010&lang=python
